### PR TITLE
Shell fixes

### DIFF
--- a/DmpWorkflow/core/views.py
+++ b/DmpWorkflow/core/views.py
@@ -228,7 +228,7 @@ class SetJobStatus(MethodView):
         bdy = literal_eval(arguments.get("body",str(dummy_dict)))
         major_status = arguments["major_status"]
         minor_status = arguments.get("minor_status",None)
-        logger.info("BODY: %s (type %s)",bdy,type(bdy))
+        logger.debug("BODY: %s (type %s)",bdy,type(bdy))
         if 'body' in arguments: del arguments['body']
         try:
             jInstance = None
@@ -252,7 +252,7 @@ class SetJobStatus(MethodView):
                 if major_status != oldStatus:
                     jInstance.setStatus(major_status)
                     #jInstance.setBody(bdy)
-                    del arguments['body']
+                    if 'body' in arguments: del arguments['body']
                 for key in ["t_id","inst_id","major_status"]: del arguments[key]
                 for key,value in arguments.iteritems():
                     jInstance.set(key,value)

--- a/DmpWorkflow/scripts/dampe_execute_payload.py
+++ b/DmpWorkflow/scripts/dampe_execute_payload.py
@@ -43,6 +43,11 @@ def __prepare(job, resources=None):
     return 0
 
 def __runPayload(job, resources=None):
+    def __file_cleanup(file1, file2):
+        file1.close()
+        file2.close()
+        rm(file1.name)
+        rm(file2.name)
     with open('payload', 'w') as foop: 
         foop.write(job.exec_wrapper)
         foop.close()
@@ -59,13 +64,11 @@ def __runPayload(job, resources=None):
         try:
             job.updateStatus("Running" if DEBUG_TEST else "Failed", "ApplicationExitCode%i" % rc, resources=resources)
         except Exception as err: logThis("EXCEPTION: %s",err)
-        rm(output.name)
-        rm(error.name)
+        __file_cleanup(output, error)
         if not DEBUG_TEST: return 5
     logThis("successfully completed running application")
     logThis("content of current working directory %s: %s",abspath(curdir),str(listdir(curdir)))
-    rm(output.name)
-    rm(error.name)
+    __file_cleanup(output, error)
     return 0
 
 def __postRun(job, resources=None):

--- a/DmpWorkflow/scripts/dampe_execute_payload.py
+++ b/DmpWorkflow/scripts/dampe_execute_payload.py
@@ -50,18 +50,22 @@ def __runPayload(job, resources=None):
     CMD = "%s payload" % job.executable
     logThis("CMD: %s", CMD)
     job.updateStatus("Running", "ExecutingApplication", resources=resources)
-    output, error, rc = run(CMD.split(),suppressLevel=True)
-    for o in output.split("\n"): print o
+    output, error, rc = run(CMD.split(),suppressLevel=True, cache=True, chunksize=36) # use caching to file!
+    for o in output: print o
     if rc:
         logThis("ERROR: Payload returned exit code %i, see below for more details.", rc)
-        for e in error.split("\n"):
+        for e in error:
             if len(e): logThis("ERROR: %s",e)
         try:
             job.updateStatus("Running" if DEBUG_TEST else "Failed", "ApplicationExitCode%i" % rc, resources=resources)
         except Exception as err: logThis("EXCEPTION: %s",err)
+        rm(output.name)
+        rm(error.name)
         if not DEBUG_TEST: return 5
     logThis("successfully completed running application")
     logThis("content of current working directory %s: %s",abspath(curdir),str(listdir(curdir)))
+    rm(output.name)
+    rm(error.name)
     return 0
 
 def __postRun(job, resources=None):

--- a/DmpWorkflow/utils/shell.py
+++ b/DmpWorkflow/utils/shell.py
@@ -52,7 +52,7 @@ def run(cmd_args, useLogging=True, suppressErrors=False, interleaved=True, suppr
                     if len(line) > 0:
                         if suppressErrors: continue
                         chunk_err.append(line[:-1])
-                        val = args[1][-1]
+                        val = chunk_err[-1] if len(chunk_err) else args[1][-1]
                         if useLogging: logger.error(val)
                         if interleaved: 
                             chunk.append(val if suppressLevel else "*ERROR*: %s"%val)


### PR DESCRIPTION
addresses #34 to avoid loading output from payload straight into memory. run() allows for pre-caching. 